### PR TITLE
ext_algorithm.hpp is included using quotes, not angle brackets

### DIFF
--- a/src/meevent.hpp
+++ b/src/meevent.hpp
@@ -30,7 +30,7 @@
 #include "config.h"
 #endif
 
-#include <ext_algorithm.hpp>
+#include "ext_algorithm.hpp"
 
 #include "eventspace.hpp"
 


### PR DESCRIPTION
I tried using the library on my Ubuntu 12.10 system and ran into another include problem.

The ext_algorithm.hpp header file is being included using the `#include <ext_algorithm.hpp>` notation, which looks for the header file only in standard header locations. I switched it to the `#include "ext_algorithm.hpp` style, so the preprocessor looks for the header file in the [prefix]/include/maxent directory instead of just looking only in the inlude directories.

Before the change, I got compilation errors in the preprocessor phase. After the change, everything compiles without a problem.
